### PR TITLE
Geoapify API 연동 및 Attraction 모듈 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ChatGPT와 직접 연동하여 사용자가 원하는 도시와 일정에 맞는
 - **Language**: Node.js (>=18.x)
 - **Package Manager**: pnpm
 - **Protocol**: [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
-- **APIs**: OpenWeather, OpenTripMap (Free Tier)
+- **APIs**: OpenWeather, Geoapify
 
 ---
 
@@ -34,7 +34,7 @@ pnpm install
 
 ```bash
 OPENWEATHER_API_KEY=your_openweather_api_key
-OPENTRIPMAP_API_KEY=your_opentripmap_api_key
+GEOAPIFY_API_KEY=your_opentripmap_api_key
 PORT=3000
 ```
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,10 +6,13 @@ import { WeatherService } from './weather/weather.service';
 import { RpcController } from './rpc/rpc.controller';
 import { WeatherModule } from './weather/weather.module';
 import { ConfigModule } from '@nestjs/config';
+import { AttractionController } from './attraction/attraction.controller';
+import { AttractionService } from './attraction/attraction.service';
+import { AttractionModule } from './attraction/attraction.module';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), WeatherModule],
-  controllers: [AppController, RpcController],
+  imports: [ConfigModule.forRoot({ isGlobal: true }), WeatherModule, AttractionModule],
+  controllers: [AppController, RpcController, AttractionController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/src/attraction/attraction.controller.ts
+++ b/src/attraction/attraction.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { AttractionService } from './attraction.service';
+
+@Controller()
+export class AttractionController {
+  constructor(private readonly attractionService: AttractionService) {}
+
+  @Get('/attractions/:city/limit/:limit')
+  async getAttractions(@Param('city') city: string, @Param('limit') limit: number): Promise<any> {
+    return this.attractionService.getAttractions(city, limit);
+  }
+}

--- a/src/attraction/attraction.module.ts
+++ b/src/attraction/attraction.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { AttractionController } from './attraction.controller';
+import { AttractionService } from './attraction.service';
+
+@Module({
+  imports: [HttpModule],
+  controllers: [AttractionController],
+  providers: [AttractionService],
+  exports: [AttractionService],
+})
+export class AttractionModule {}

--- a/src/attraction/attraction.service.ts
+++ b/src/attraction/attraction.service.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { lastValueFrom } from 'rxjs';
+
+@Injectable()
+export class AttractionService {
+  private readonly apiKey: string;
+
+  constructor(
+    private readonly http: HttpService,
+    private readonly configService: ConfigService
+  ) {
+    this.apiKey = this.configService.get<string>('GEOAPIFY_API_KEY') ?? '';
+  }
+
+  /**
+   * 도시의 관광지 조회
+   * @param city
+   * @param limit
+   */
+  async getAttractions(city: string, limit: number): Promise<any> {
+    try {
+      // 1. 도시명 → 좌표 변환
+      const geocodeUrl = `https://api.geoapify.com/v1/geocode/search`;
+      const geocodeResponse = await lastValueFrom(
+        this.http.get(geocodeUrl, {
+          params: { text: city, apiKey: this.apiKey },
+        }),
+      );
+
+      if (!geocodeResponse.data.features?.length) {
+        return { error: `No coordinates found for ${city}` };
+      }
+
+      const { lat, lon } = geocodeResponse.data.features[0].properties;
+
+      // 2. 관광지 조회
+      const placesUrl = `https://api.geoapify.com/v2/places`;
+      const placesResponse = await lastValueFrom(
+        this.http.get(placesUrl, {
+          params: {
+            categories: 'tourism.sights,tourism.attraction',
+            filter: `circle:${lon},${lat},5000`, // 반경 5km
+            limit, // 최대 개수
+            apiKey: this.apiKey,
+          },
+        }),
+      );
+
+      const attractions = placesResponse.data.features.map((place: any) => ({
+        name: place.properties.name,
+        category: place.properties.category,
+        address: place.properties.address_line1 || '',
+        distance: place.properties.distance || null,
+      }));
+
+      return {
+        city,
+        attractions,
+        source: 'Geoapify - Geocode, Places API'
+      };
+
+    } catch (error) {
+      return {
+        error: 'Failed to fetch attractions',
+        details: error.response?.data || error.message,
+      };
+    }
+  }
+}

--- a/src/rpc/rpc.controller.ts
+++ b/src/rpc/rpc.controller.ts
@@ -1,9 +1,13 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { WeatherService } from '../weather/weather.service';
+import { AttractionService } from '../attraction/attraction.service';
 
 @Controller()
 export class RpcController {
-  constructor(private readonly weatherService: WeatherService) {}
+  constructor(
+    private readonly weatherService: WeatherService,
+    private readonly attractionService: AttractionService,
+  ) {}
 
   /**
    * JSON-RPC 스타일, MCP에서 RPC 호출하여 사용
@@ -51,6 +55,9 @@ export class RpcController {
         case 'getWeather':
           const weather = await this.weatherService.getWeather(params.city);
           return { jsonrpc: '2.0', result: weather, id };
+        case 'getAttractions':
+          const attractions = await this.attractionService.getAttractions(params.city, params.limit || 10);
+          return { jsonrpc: '2.0', result: attractions, id };
         default:
           return { jsonrpc: '2.0', error: { code: -32601, message: 'Method not found' }, id };
       }


### PR DESCRIPTION
### 작업 사항
- Attraction 모듈 추가 작업
    - Attraction Service에서 Geoapify API 연동
    - 도시의 주요 관광지 조회 엔드포인트 추가
    - JSON-RPC `getAttractions` 엔드포인트 추가

### Issue
- #2 
